### PR TITLE
Bias Tee for AirSpy (Spyverter / NLA)

### DIFF
--- a/dat/config/nfc-lab.conf
+++ b/dat/config/nfc-lab.conf
@@ -38,6 +38,7 @@ gainMode=1
 gainValue=4
 tunerAgc=false
 mixerAgc=false
+biasTee=0
 centerFreq=40680000
 sampleRate=10000000
 
@@ -46,6 +47,7 @@ gainMode=0
 gainValue=125
 tunerAgc=false
 mixerAgc=false
+biasTee=0
 centerFreq=27120000
 sampleRate=2400000
 

--- a/src/nfc-app/app-qt/src/main/cpp/QtDecoder.cpp
+++ b/src/nfc-app/app-qt/src/main/cpp/QtDecoder.cpp
@@ -522,6 +522,9 @@ struct QtDecoder::Impl
       if (event->contains("tunerAgc"))
          json["tunerAgc"] = event->getInteger("tunerAgc");
 
+      if (event->contains("biasTee"))
+         json["biasTee"] = event->getInteger("biasTee");
+
       taskReceiverConfig(json);
    }
 

--- a/src/nfc-app/app-qt/src/main/cpp/QtWindow.cpp
+++ b/src/nfc-app/app-qt/src/main/cpp/QtWindow.cpp
@@ -96,6 +96,7 @@ struct QtWindow::Impl
    int deviceSampleCount = 0;
    int deviceGainMode = -1;
    int deviceGainValue = -1;
+   int deviceBiasTee = 0;
 
    // last decoder status received
    QString decoderStatus;
@@ -361,6 +362,7 @@ struct QtWindow::Impl
             updateSampleRate(settings.value("device." + deviceType + "/sampleRate", "10000000").toInt());
             updateGainMode(settings.value("device." + deviceType + "/gainMode", "1").toInt());
             updateGainValue(settings.value("device." + deviceType + "/gainValue", "6").toInt());
+            updateBiasTee(settings.value("device." + deviceType + "/biasTee", "0").toInt());
 
             ui->eventsLog->append(QString("Detected device %1").arg(deviceName));
          }
@@ -560,6 +562,21 @@ struct QtWindow::Impl
                   {"gainValue", deviceGainValue}
             }));
          }
+      }
+   }
+
+   void updateBiasTee(int value)
+   {
+      if (deviceBiasTee != value)
+      {
+         deviceBiasTee = value;
+
+         qInfo() << "receiver deviceBiasTee value changed:" << value;
+
+         if (!deviceType.isEmpty())
+            settings.setValue("device." + deviceType + "/biasTee", deviceBiasTee);
+
+         QtApplication::post(new DecoderControlEvent(DecoderControlEvent::ReceiverConfig, { {"biasTee", deviceBiasTee} }));
       }
    }
 

--- a/src/nfc-app/app-qt/src/main/cpp/events/ReceiverStatusEvent.cpp
+++ b/src/nfc-app/app-qt/src/main/cpp/events/ReceiverStatusEvent.cpp
@@ -145,6 +145,16 @@ int ReceiverStatusEvent::mixerAgc() const
    return data["mixerAgc"].toInt();
 }
 
+bool ReceiverStatusEvent::hasBiasTee() const
+{
+   return data.contains("biasTee");
+}
+
+int ReceiverStatusEvent::biasTee() const
+{
+   return data["biasTee"].toInt();
+}
+
 bool ReceiverStatusEvent::hasSignalPower() const
 {
    return false; //mInfo & SignalPower;

--- a/src/nfc-app/app-qt/src/main/cpp/events/ReceiverStatusEvent.h
+++ b/src/nfc-app/app-qt/src/main/cpp/events/ReceiverStatusEvent.h
@@ -88,6 +88,10 @@ class ReceiverStatusEvent : public QEvent
       bool hasMixerAgc() const;
 
       int mixerAgc() const;
+	  
+      bool hasBiasTee() const;
+
+      int biasTee() const;
 
       bool hasSignalPower() const;
 

--- a/src/nfc-app/app-qt/src/main/cpp/model/StreamModel.cpp
+++ b/src/nfc-app/app-qt/src/main/cpp/model/StreamModel.cpp
@@ -166,7 +166,7 @@ struct StreamModel::Impl
 
       double elapsed = frame->timeStart() - prev->timeEnd();
 
-      if (elapsed < 1E-3)
+      if (elapsed < 20E-3)
          return QString("%1 us").arg(elapsed * 1000000, 3, 'f', 0);
 
       if (elapsed < 1)

--- a/src/nfc-lib/lib-nfc/nfc-tasks/src/main/cpp/SignalReceiverTask.cpp
+++ b/src/nfc-lib/lib-nfc/nfc-tasks/src/main/cpp/SignalReceiverTask.cpp
@@ -181,6 +181,7 @@ struct SignalReceiverTask::Impl : SignalReceiverTask, AbstractTask
 
                receiver->setMixerAgc(0);
                receiver->setTunerAgc(0);
+               receiver->setBiasTee(0);
                receiver->setTestMode(0);
 
                // try to open...
@@ -290,6 +291,9 @@ struct SignalReceiverTask::Impl : SignalReceiverTask, AbstractTask
             if (config.contains("mixerAgc"))
                receiver->setMixerAgc(config["mixerAgc"]);
 
+            if (config.contains("biasTee"))
+               receiver->setBiasTee(config["biasTee"]);
+
             if (config.contains("gainMode"))
             {
                receiverGainMode = config["gainMode"];
@@ -341,6 +345,7 @@ struct SignalReceiverTask::Impl : SignalReceiverTask, AbstractTask
          data["gainValue"] = receiver->gainValue();
          data["mixerAgc"] = receiver->mixerAgc();
          data["tunerAgc"] = receiver->tunerAgc();
+         data["biasTee"] = receiver->biasTee();
 
          // data statistics
          data["samplesReceived"] = receiver->samplesReceived();

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/AirspyDevice.cpp
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/AirspyDevice.cpp
@@ -55,6 +55,7 @@ struct AirspyDevice::Impl
    int gainValue = 0;
    int tunerAgc = 0;
    int mixerAgc = 0;
+   int biasTee = 0;
    int decimation = 0;
    int streamTime = 0;
 
@@ -151,10 +152,6 @@ struct AirspyDevice::Impl
          if ((airspyResult = airspy_version_string_read(handle, tmp, sizeof(tmp))) != AIRSPY_SUCCESS)
             log.warn("failed airspy_version_string_read: [{}] {}", {airspyResult, airspy_error_name((enum airspy_error) airspyResult)});
 
-         // disable bias tee
-         if ((airspyResult = airspy_set_rf_bias(handle, 0)) != AIRSPY_SUCCESS)
-            log.warn("failed airspy_set_rf_bias: [{}] {}", {airspyResult, airspy_error_name((enum airspy_error) airspyResult)});
-
          // read board serial
          if ((airspyResult = airspy_board_partid_serialno_read(handle, &airspySerial)) != AIRSPY_SUCCESS)
             log.warn("failed airspy_board_partid_serialno_read: [{}] {}", {airspyResult, airspy_error_name((enum airspy_error) airspyResult)});
@@ -177,6 +174,9 @@ struct AirspyDevice::Impl
 
          // configure gain value
          setGainValue(gainValue);
+		 
+         // configure bias tee (LNA or SpyVerter)
+         setBiasTee(biasTee);		 
 
          log.info("openned airspy device {}, firmware {}", {deviceName, deviceVersion});
 
@@ -194,6 +194,10 @@ struct AirspyDevice::Impl
       {
          // stop streaming if active...
          stop();
+		 
+         // disable bias tee
+         if ((airspyResult = airspy_set_rf_bias(airspyHandle, 0)) != AIRSPY_SUCCESS)
+             log.warn("failed airspy_set_rf_bias: [{}] {}", { airspyResult, airspy_error_name((enum airspy_error)airspyResult) });
 
          log.info("close device {}", {deviceName});
 
@@ -388,6 +392,21 @@ struct AirspyDevice::Impl
       {
          if ((airspyResult = airspy_set_mixer_agc(airspyHandle, mixerAgc)) != AIRSPY_SUCCESS)
             log.warn("failed airspy_set_mixer_agc: [{}] {}", {airspyResult, airspy_error_name((enum airspy_error) airspyResult)});
+
+         return airspyResult;
+      }
+
+      return 0;
+   }
+
+   int setBiasTee(int value)
+   {
+      biasTee = value;
+
+      if (airspyHandle)
+      {
+         if ((airspyResult = airspy_set_rf_bias(airspyHandle, biasTee)) != AIRSPY_SUCCESS)
+            log.warn("failed airspy_set_rf_bias: [{}] {}", { airspyResult, airspy_error_name((enum airspy_error)airspyResult) });
 
          return airspyResult;
       }
@@ -625,6 +644,16 @@ int AirspyDevice::mixerAgc() const
 int AirspyDevice::setMixerAgc(int value)
 {
    return impl->setMixerAgc(value);
+}
+
+int AirspyDevice::biasTee() const
+{
+   return impl->biasTee;
+}
+
+int AirspyDevice::setBiasTee(int value)
+{
+   return impl->setBiasTee(value);
 }
 
 int AirspyDevice::gainMode() const

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
@@ -747,6 +747,18 @@ int RealtekDevice::setMixerAgc(int value)
    return impl->setMixerAgc(value);
 }
 
+int RealtekDevice::biasTee() const
+{
+   return 0;
+}
+
+int RealtekDevice::setBiasTee(int value)
+{
+   impl->log.warn("setBiasTee has no effect!");
+
+   return -1;
+}
+
 int RealtekDevice::gainMode() const
 {
    return impl->gainMode;

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/AirspyDevice.h
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/AirspyDevice.h
@@ -102,6 +102,10 @@ class AirspyDevice : public RadioDevice
 
       int setMixerAgc(int value) override;
 
+      int biasTee() const override;
+
+      int setBiasTee(int value) override;
+
       int gainMode() const override;
 
       int setGainMode(int value) override;

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/RadioDevice.h
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/RadioDevice.h
@@ -56,6 +56,10 @@ class RadioDevice : public SignalDevice
 
       virtual int setMixerAgc(int value) = 0;
 
+      virtual int biasTee() const = 0;
+
+      virtual int setBiasTee(int value) = 0;
+
       virtual int gainMode() const = 0;
 
       virtual int setGainMode(int value) = 0;

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/RealtekDevice.h
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/RealtekDevice.h
@@ -100,6 +100,10 @@ class RealtekDevice : public RadioDevice
 
       int setMixerAgc(int value) override;
 
+      int biasTee() const override;
+
+      int setBiasTee(int value) override;
+
       int gainMode() const override;
 
       int setGainMode(int value) override;


### PR DESCRIPTION
Add option in nfc-lab.conf (biasTee) to power Spyverter or other active NLA with Airspy device

Example:
- biasTee=1
- centerFreq=133560000