### PR TITLE
Direct sampling 13.56Mhz on rtl-sdr

### DIFF
--- a/dat/config/nfc-lab.conf
+++ b/dat/config/nfc-lab.conf
@@ -48,7 +48,7 @@ gainValue=125
 tunerAgc=false
 mixerAgc=false
 biasTee=0
-centerFreq=27120000
+centerFreq=13560000
 sampleRate=2400000
 
 [keys.default]

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
@@ -68,6 +68,7 @@ struct RealtekDevice::Impl
    int decimation = 0;
    int testMode = 0;
    int streamTime = 0;
+   int directSampling = 0;
 
    int rtlsdrResult = 0;
    rtlsdr_dev *rtlsdrHandle {};
@@ -175,6 +176,9 @@ struct RealtekDevice::Impl
 
             // configure gain value
             setGainValue(gainValue);
+
+            // configure direct sampling
+            setDirectSampling(directSampling);
 
             log.info("openned rtlsdr device {} width tuner type {}", {deviceName, rtlsdrTuner});
 
@@ -442,6 +446,23 @@ struct RealtekDevice::Impl
 
          if ((rtlsdrResult = rtlsdr_set_testmode(rtldev(rtlsdrHandle), testMode)) < 0)
             log.warn("failed rtlsdr_set_testmode: [{}]", {rtlsdrResult});
+
+         return rtlsdrResult;
+      }
+
+      return 0;
+   }
+
+   int setDirectSampling(int value)
+   {
+      directSampling = value;
+
+      if (rtlsdrHandle)
+      {
+         log.debug("rtlsdr_set_direct_sampling({})", {directSampling});
+
+         if ((rtlsdrResult = rtlsdr_set_direct_sampling(rtldev(rtlsdrHandle), directSampling)) < 0)
+            log.warn("failed rtlsdr_set_direct_sampling: [{}]", {rtlsdrResult});
 
          return rtlsdrResult;
       }
@@ -797,6 +818,17 @@ int RealtekDevice::testMode() const
 int RealtekDevice::setTestMode(int value)
 {
    return impl->setTestMode(value);
+}
+
+int RealtekDevice::directSampling() const
+{
+   // should report the same as rtlsdr_get_direct_sampling
+   return impl->directSampling;
+}
+
+int RealtekDevice::setDirectSampling(int value)
+{
+   return impl->setDirectSampling(value);
 }
 
 long RealtekDevice::samplesReceived()

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
@@ -68,7 +68,7 @@ struct RealtekDevice::Impl
    int decimation = 0;
    int testMode = 0;
    int streamTime = 0;
-   int directSampling = 0;
+   int directSampling = 2;
 
    int rtlsdrResult = 0;
    rtlsdr_dev *rtlsdrHandle {};

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/RealtekDevice.h
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/include/sdr/RealtekDevice.h
@@ -124,6 +124,10 @@ class RealtekDevice : public RadioDevice
 
       long samplesDropped() override;
 
+      int directSampling() const;
+
+      int setDirectSampling(int value);
+
       std::map<int, std::string> supportedSampleRates() const override;
 
       std::map<int, std::string> supportedGainValues() const override;


### PR DESCRIPTION
Hi!

I've created a proof of concept for using direct sampling on the rtl-sdr device.
This means we can listen directly to the main carrier frequency of 13.56Mhz.

With my limited testing, and completely wrong antenna type, I still got great results.
Almost all pakcets are correctly read, as far as I can tell:
![image](https://user-images.githubusercontent.com/17357504/213695230-7a9278eb-1882-496c-83bc-88ec14f75e93.png)

Now in order to include this in the upstream project, some things still need to be done.
I'm thinking:
1. This needs to be configurabe from the config file, instead of being hardcoded in [RealtekDevice.cpp#L71](https://github.com/vinicentus/nfc-laboratory/blob/direct-sampling/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp#L71)
2. This change needs to be documented, at least in the readme.

So yeah. This is a work in progress, and therefore marked as a draft pull request.
But hopefully you find this useful, and hopefully it can be merged at some point!

Best regards,
Vincent