### PR TITLE
Fixed Linux build of app-test because of mingw32 and psapi libraries

### DIFF
--- a/src/nfc-test/app-test/CMakeLists.txt
+++ b/src/nfc-test/app-test/CMakeLists.txt
@@ -9,11 +9,14 @@ add_executable(nfc-test
 target_include_directories(nfc-test PRIVATE ${PRIVATE_SOURCE_DIR})
 target_include_directories(nfc-test PRIVATE ${AUTOGEN_BUILD_DIR}/include)
 
+if (WIN32)
+    set(PLATFORM_LIBS mingw32 psapi)
+endif (WIN32)
+
 target_link_libraries(nfc-test
+        ${PLATFORM_LIBS}
         nfc-decode
         sdr-io
         rt-lang
         nlohmann
-        mingw32
-        psapi
         )


### PR DESCRIPTION
I was unable to build app on Linux because of missing Windows-related libraries so I solved it just like in CMakeLists.txt of app-qt.