### PR TITLE
Fix signal graph under Linux

### DIFF
--- a/src/nfc-lib/lib-nfc/nfc-tasks/src/main/cpp/AdaptiveSamplingTask.cpp
+++ b/src/nfc-lib/lib-nfc/nfc-tasks/src/main/cpp/AdaptiveSamplingTask.cpp
@@ -133,7 +133,7 @@ struct AdaptiveSamplingTask::Impl : AdaptiveSamplingTask, AbstractTask
             avrg -= buffer[r];
 
          // detect deviation from average
-         float stdev = abs(value - (avrg / float(WINDOW)));
+         float stdev = std::abs(value - (avrg / float(WINDOW)));
 
          // filter values
          if (stdev > filter || (i - c) > 100)


### PR DESCRIPTION
abs() does not work on float under Linux
so computed `stdev` was always =0 and we only got 1/100 of the samples via `(i - c) > 100`
