### PR TITLE
Resolve compiler warnings

### DIFF
--- a/src/nfc-app/app-qt/src/main/cpp/3party/customplot/QCustomPlot.cpp
+++ b/src/nfc-app/app-qt/src/main/cpp/3party/customplot/QCustomPlot.cpp
@@ -679,7 +679,7 @@ QCPPainter *QCPPaintBufferPixmap::startPainting()
 {
   QCPPainter *result = new QCPPainter(&mBuffer);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-  result->setRenderHint(QPainter::HighQualityAntialiasing);
+  result->setRenderHint(QPainter::Antialiasing);
 #endif
   return result;
 }
@@ -768,7 +768,7 @@ QCPPainter *QCPPaintBufferGlPbuffer::startPainting()
   }
   
   QCPPainter *result = new QCPPainter(mGlPBuffer);
-  result->setRenderHint(QPainter::HighQualityAntialiasing);
+  result->setRenderHint(QPainter::Antialiasing);
   return result;
 }
 
@@ -881,7 +881,7 @@ QCPPainter *QCPPaintBufferGlFbo::startPainting()
   mGlFrameBuffer->bind();
   QCPPainter *result = new QCPPainter(paintDevice.data());
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-  result->setRenderHint(QPainter::HighQualityAntialiasing);
+  result->setRenderHint(QPainter::Antialiasing);
 #endif
   return result;
 }

--- a/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
+++ b/src/nfc-lib/lib-sdr/sdr-io/src/main/cpp/RealtekDevice.cpp
@@ -119,9 +119,17 @@ struct RealtekDevice::Impl
 
          if (rtlsdr_get_device_usb_strings(i, manufact, product, serial) == 0)
          {
-            snprintf(buffer, sizeof(buffer), "rtlsdr://%s", serial);
+            // 1015 = 1024 - len "rtlsdr://" - 1
+            if (strlen(serial) < 1015)
+            {
+               snprintf(buffer, sizeof(buffer), "rtlsdr://%s", serial);
 
-            result.emplace_back(buffer);
+               result.emplace_back(buffer);
+            }
+            else
+            {
+               fprintf(stderr, "Error: Serial string is too long for device %d\n", i);
+            }
          }
       }
 


### PR DESCRIPTION
As I have already written to you in [josevcm/nfc-laboratory/pull/35](https://github.com/josevcm/nfc-laboratory/pull/35). It is nice to have to avoid warnings when compiling.