### PR TITLE
Fix `PARAM_LIMIT_SAMPLES` to avoid overflow in DSLogic settings

### DIFF
--- a/src/nfc-lib/lib-lab/lab-tasks/src/main/cpp/tasks/LogicDeviceTask.cpp
+++ b/src/nfc-lib/lib-lab/lab-tasks/src/main/cpp/tasks/LogicDeviceTask.cpp
@@ -238,7 +238,7 @@ struct LogicDeviceTask::Impl : LogicDeviceTask, AbstractTask
 
       // default parameters for DSLogic
       device->set(hw::LogicDevice::PARAM_OPERATION_MODE, hw::DSLogicDevice::OP_STREAM);
-      device->set(hw::LogicDevice::PARAM_LIMIT_SAMPLES, static_cast<unsigned long long>(-1));
+      device->set(hw::LogicDevice::PARAM_LIMIT_SAMPLES, static_cast<unsigned long long>(std::numeric_limits<uint32_t>::max()));
 
       // setup sample rate
       if (config.contains("sampleRate"))


### PR DESCRIPTION
In `LogicDeviceTask.cpp`: set `PARAM_LIMIT_SAMPLES` to `std::numeric_limits<uint32_t>::max()` instead of `-1` to avoid potential overflow in `DSLogicDevice.cpp` with `captureSamples = (limitSamples + SAMPLES_ALIGN) & ~SAMPLES_ALIGN;`