### PR TITLE
Finish Mirics support

### DIFF
--- a/src/nfc-app/app-rx/src/main/cpp/main.cpp
+++ b/src/nfc-app/app-rx/src/main/cpp/main.cpp
@@ -109,6 +109,20 @@ struct Main
             {"biasTee", 0},
             {"directSampling", 0}
          }
+      },
+
+      // Mirics MSi2500
+      {
+         "radio.miri", {
+            {"centerFreq", 13560000},
+            {"sampleRate", 10000000},
+            {"gainMode", 1}, // linearity
+            {"gainValue", 0}, // 0db
+            {"mixerAgc", 0},
+            {"tunerAgc", 0},
+            {"biasTee", 0},
+            {"directSampling", 0}
+         }
       }
    };
 


### PR DESCRIPTION
These are the initial changes as discussed in #86.
I have the `Mirics MSi2500 default (e.g. VTX3D card)` to test this on, but currently the GUI app crashes in an FFT function and the `nfc-rx` app runs but does not show any captured commands except RF on/off.