### PR TITLE
ci: Add macOS build job to GitHub Actions workflow

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -61,6 +61,36 @@ jobs:
           name: linux-artifact
           path: ${{ github.workspace }}/*.deb
 
+  build-macos:
+
+    runs-on: macos-latest
+
+    steps:
+
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+
+      - name: 'Set reusable strings'
+        id: strings-macos
+        shell: bash
+        run: |
+          echo "build-name=${{ (github.ref_name == 'master' || github.ref_name == 'develop') && 'snapshot' || github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "build-version=${{ (github.ref_name == 'master' || github.ref_name == 'develop') && '0.0.0' || github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "cpu-count=4" >> "$GITHUB_OUTPUT"
+
+      - name: 'Install dependencies'
+        run: |
+          brew install mesa libusb qt qtsvg cmake gcc
+
+      - name: 'Build project'
+        run: |
+          mkdir build
+          cd build
+          cmake .. `
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `
+            -DBUILD_PROJECT_VERSION="${{ steps.strings-macos.outputs.build-version }}"
+          make -j ${{ steps.strings-macos.outputs.cpu-count }}
+
   #
   # Windows build job
   #


### PR DESCRIPTION
This adds a simple build step on a macos runner. It's just meant to verify that nothing is broken for that (and also somewhat doubles as documentation on how to build on macos) - it's intentionally not tied into the releasing. It's a bit of a pain with the signing nowadays, and really not that complicated to build  from source.