### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ src/nfc-app/app-qt/src/main/cpp/QtConfig.h
 .flatpak-builder/
 build-dir/
 repo/
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to `.gitignore` so that the Claude Code guidance file stays local and is never committed to the public repository.

## Why

`CLAUDE.md` is auto-generated by Claude Code to help AI assistants navigate the codebase. It is a developer-local artifact and does not belong in the public repo.

## Reviewer notes

No functional code changes — single-line addition to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)